### PR TITLE
gui

### DIFF
--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/TCGui.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/TCGui.kt
@@ -1,6 +1,7 @@
 package net.cydhra.technocracy.foundation.client.gui
 
 import net.cydhra.technocracy.foundation.client.gui.components.slot.TCSlot
+import net.cydhra.technocracy.foundation.client.gui.components.slot.TCSlotIO
 import net.cydhra.technocracy.foundation.client.gui.tabs.TCTab
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
@@ -9,6 +10,7 @@ import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.client.renderer.RenderHelper
 import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.inventory.Slot
 import net.minecraft.util.ResourceLocation
 import net.minecraftforge.fml.client.config.GuiUtils
 
@@ -81,13 +83,15 @@ TCContainer)
             if (this.isPointInRegion(x, y, width, height, mouseX, mouseY)) {
                 this.tab = it
 
-                this.tabs.withIndex()
-                        .forEach { (index, tab) ->
-                            tab.components
-                                    .filterIsInstance<TCSlot>()
-                                    .map { index to it }
-                                    .forEach { pair -> pair.second.isEnabled = pair.first == it }
+                this.tabs.withIndex().forEach { (index, tab) ->
+                    tab.components.filterIsInstance<Slot>().map { index to it }.forEach { pair ->
+                        if(pair.second is TCSlot) {
+                            (pair.second as TCSlot).isEnabled = pair.first == it
+                        } else if(pair.second is TCSlotIO) {
+                            (pair.second as TCSlotIO).isEnabled = pair.first == it
                         }
+                    }
+                }
             }
         }
     }

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/components/label/DefaultLabel.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/components/label/DefaultLabel.kt
@@ -1,0 +1,10 @@
+package net.cydhra.technocracy.foundation.client.gui.components.label
+
+import net.minecraft.client.Minecraft
+
+class DefaultLabel(posX: Int, posY: Int, text: String, val color: Int = 0xffffff):Label(posX, posY, text, Minecraft.getMinecraft().fontRenderer) {
+
+    override fun draw(mouseX: Int, mouseY: Int, partialTicks: Float) {
+        fontRenderer.drawString(text, posX, posY, color)
+    }
+}

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/components/label/Label.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/components/label/Label.kt
@@ -1,0 +1,17 @@
+package net.cydhra.technocracy.foundation.client.gui.components.label
+
+import net.cydhra.technocracy.foundation.client.gui.components.TCComponent
+import net.minecraft.client.gui.FontRenderer
+
+abstract class Label(val posX: Int, val posY: Int, val text: String, val fontRenderer: FontRenderer) : TCComponent {
+
+    override fun drawTooltip(mouseX: Int, mouseY: Int) {}
+
+    override fun update() {}
+
+    override fun mouseClicked(mouseX: Int, mouseY: Int, mouseButton: Int) {}
+
+    override fun isMouseOnComponent(mouseX: Int, mouseY: Int): Boolean {
+        return mouseX > posX && mouseX < posX + fontRenderer.getStringWidth(text) && mouseY > posY && mouseY < posY + fontRenderer.FONT_HEIGHT
+    }
+}

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/components/redstonemode/DefaultRedstoneModeControl.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/components/redstonemode/DefaultRedstoneModeControl.kt
@@ -1,16 +1,22 @@
 package net.cydhra.technocracy.foundation.client.gui.components.redstonemode
 
+import it.zerono.mods.zerocore.api.multiblock.MultiblockTileEntityBase
 import net.cydhra.technocracy.foundation.client.gui.TCGui
+import net.cydhra.technocracy.foundation.multiblock.BaseMultiBlock
+import net.cydhra.technocracy.foundation.network.PacketHandler
+import net.cydhra.technocracy.foundation.network.componentsync.ClientComponentUpdatePacket
+import net.cydhra.technocracy.foundation.tileentity.api.TCAggregatable
 import net.cydhra.technocracy.foundation.tileentity.components.RedstoneModeComponent
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
 import net.minecraft.client.renderer.GlStateManager
+import net.minecraft.nbt.NBTTagCompound
 
 class DefaultRedstoneModeControl(posX: Int, posY: Int, val component: RedstoneModeComponent, val gui: TCGui) : RedstoneModeControl(posX, posY) {
 
     override fun draw(mouseX: Int, mouseY: Int, partialTicks: Float) {
         super.draw(mouseX, mouseY, partialTicks)
-        val clr = if(hovered) 0.7f else 1f
+        val clr = if (hovered) 0.7f else 1f
         GlStateManager.color(clr, clr, clr, 1f)
         Minecraft.getMinecraft().textureManager.bindTexture(TCGui.guiComponents)
         Gui.drawModalRectWithCustomSizedTexture(posX, posY, component.redstoneMode.ordinal * 16f, 59f, width, height, 256f, 256f)
@@ -23,5 +29,14 @@ class DefaultRedstoneModeControl(posX: Int, posY: Int, val component: RedstoneMo
 
     override fun mouseClicked(mouseX: Int, mouseY: Int, mouseButton: Int) {
         component.redstoneMode = RedstoneModeComponent.RedstoneMode.values()[(component.redstoneMode.ordinal + 1) % RedstoneModeComponent.RedstoneMode.values().size]
+        val tag = NBTTagCompound()
+        tag.setTag("component", component.serializeNBT())
+        if (component.tile is MultiblockTileEntityBase) { // not tested yet for multiblocks (because multiblocks currently haven't redstonemode stuff)
+            tag.setString("name", ((component.tile as MultiblockTileEntityBase).multiblockController as BaseMultiBlock).getComponents().filter { it.second == component }[0].first)
+        } else if (component.tile is TCAggregatable) {
+            tag.setString("name", (component.tile as TCAggregatable).getComponents().filter { it.second == component }[0].first)
+        }
+        tag.setLong("pos", component.tile.pos.toLong())
+        PacketHandler.sendToServer(ClientComponentUpdatePacket(tag))
     }
 }

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/components/slot/TCSlotIO.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/components/slot/TCSlotIO.kt
@@ -11,6 +11,8 @@ import net.minecraftforge.items.SlotItemHandler
 
 class TCSlotIO(itemHandler: IItemHandler, index: Int, xPosition: Int, yPosition: Int, val gui: TCGui) : SlotItemHandler(itemHandler, index, xPosition, yPosition), TCComponent {
 
+    private var enabled: Boolean = true
+
     override fun update() {
     }
 
@@ -31,6 +33,14 @@ class TCSlotIO(itemHandler: IItemHandler, index: Int, xPosition: Int, yPosition:
 
     override fun isMouseOnComponent(mouseX: Int, mouseY: Int): Boolean {
         return mouseX > xPos && mouseX < xPos + 18 && mouseY > yPos && mouseY < yPos + 18
+    }
+
+    override fun isEnabled(): Boolean {
+        return this.enabled
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        this.enabled = enabled
     }
 
 }

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/machine/BaseMachineTab.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/machine/BaseMachineTab.kt
@@ -3,16 +3,8 @@ package net.cydhra.technocracy.foundation.client.gui.machine
 import net.cydhra.technocracy.foundation.client.gui.TCGui
 import net.cydhra.technocracy.foundation.client.gui.tabs.TCTab
 import net.cydhra.technocracy.foundation.tileentity.MachineTileEntity
-import net.minecraft.client.Minecraft
-import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.util.ResourceLocation
 
 abstract class BaseMachineTab(val machine: MachineTileEntity, parent: TCGui, icon: ResourceLocation) : TCTab(name = machine.blockType.localizedName, parent = parent, icon = icon) {
-
-    override fun draw(mouseX: Int, mouseY: Int, partialTicks: Float) {
-        GlStateManager.color(1f, 1f, 1f, 1f)
-        Minecraft.getMinecraft().fontRenderer.drawString(machine.blockType.localizedName, 8f, 8f, -1, true)
-        super.draw(mouseX, mouseY, partialTicks)
-    }
 
 }

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/machine/MachineSettingsTab.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/machine/MachineSettingsTab.kt
@@ -22,8 +22,6 @@ class MachineSettingsTab(parent: TCGui, val machine: MachineTileEntity, val play
 
     override fun draw(mouseX: Int, mouseY: Int, partialTicks: Float) {
         super.draw(mouseX, mouseY, partialTicks)
-
-        Minecraft.getMinecraft().fontRenderer.drawStringWithShadow("Settings", 8f, 8f, -1)
         Minecraft.getMinecraft().fontRenderer.drawStringWithShadow("Redstone Mode: ", 10f, 24f, -1)
     }
 

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/multiblock/BaseMultiblockTab.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/multiblock/BaseMultiblockTab.kt
@@ -3,16 +3,9 @@ package net.cydhra.technocracy.foundation.client.gui.multiblock
 import net.cydhra.technocracy.foundation.client.gui.TCGui
 import net.cydhra.technocracy.foundation.client.gui.tabs.TCTab
 import net.cydhra.technocracy.foundation.tileentity.multiblock.TileEntityMultiBlockPart
-import net.minecraft.client.Minecraft
-import net.minecraft.client.renderer.GlStateManager
+
 import net.minecraft.util.ResourceLocation
 
 abstract class BaseMultiblockTab(val controller: TileEntityMultiBlockPart<*>, parent: TCGui, icon: ResourceLocation) : TCTab(name = controller.blockType.localizedName, parent = parent, icon = icon) {
-
-    override fun draw(mouseX: Int, mouseY: Int, partialTicks: Float) {
-        GlStateManager.color(1f, 1f, 1f, 1f)
-        Minecraft.getMinecraft().fontRenderer.drawString(controller.blockType.localizedName, 8f, 8f, -1, true)
-        super.draw(mouseX, mouseY, partialTicks)
-    }
 
 }

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/multiblock/MultiblockSettingsTab.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/multiblock/MultiblockSettingsTab.kt
@@ -3,7 +3,6 @@ package net.cydhra.technocracy.foundation.client.gui.multiblock
 import net.cydhra.technocracy.foundation.client.gui.TCGui
 import net.cydhra.technocracy.foundation.client.gui.tabs.TCTab
 import net.cydhra.technocracy.foundation.tileentity.multiblock.TileEntityMultiBlockPart
-import net.minecraft.client.Minecraft
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.util.ResourceLocation
 
@@ -12,12 +11,6 @@ class MultiblockSettingsTab(parent: TCGui, val controller: TileEntityMultiBlockP
 
     override fun init() {
 
-    }
-
-    override fun draw(mouseX: Int, mouseY: Int, partialTicks: Float) {
-        super.draw(mouseX, mouseY, partialTicks)
-
-        Minecraft.getMinecraft().fontRenderer.drawStringWithShadow("Settings", 8f, 8f, -1)
     }
 
 }

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/tabs/TCTab.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/tabs/TCTab.kt
@@ -58,4 +58,8 @@ abstract class TCTab(val name: String, val parent: TCGui, val tint: Int = -1,
         }
     }
 
+    protected fun addComponent(component: TCComponent) {
+        components.add(component)
+    }
+
 }

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/tabs/TCTab.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/client/gui/tabs/TCTab.kt
@@ -3,6 +3,8 @@ package net.cydhra.technocracy.foundation.client.gui.tabs
 import net.cydhra.technocracy.foundation.client.gui.TCGui
 import net.cydhra.technocracy.foundation.client.gui.components.TCComponent
 import net.cydhra.technocracy.foundation.client.gui.components.slot.TCSlot
+import net.minecraft.client.Minecraft
+import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.util.ResourceLocation
 
@@ -16,6 +18,8 @@ abstract class TCTab(val name: String, val parent: TCGui, val tint: Int = -1,
     abstract fun init()
 
     open fun draw(mouseX: Int, mouseY: Int, partialTicks: Float) {
+        GlStateManager.color(1f, 1f, 1f, 1f)
+        Minecraft.getMinecraft().fontRenderer.drawString(name, 8f, 8f, -1, true)
         this.components.forEach {
             it.draw(mouseX, mouseY, partialTicks)
         }

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/network/componentsync/ClientComponentUpdatePacket.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/network/componentsync/ClientComponentUpdatePacket.kt
@@ -1,0 +1,37 @@
+package net.cydhra.technocracy.foundation.network.componentsync
+
+import io.netty.buffer.ByteBuf
+import it.zerono.mods.zerocore.api.multiblock.MultiblockTileEntityBase
+import net.cydhra.technocracy.foundation.multiblock.BaseMultiBlock
+import net.cydhra.technocracy.foundation.tileentity.api.TCAggregatable
+import net.minecraft.nbt.NBTTagCompound
+import net.minecraft.util.math.BlockPos
+import net.minecraftforge.fml.common.network.ByteBufUtils
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext
+
+class ClientComponentUpdatePacket(var tag: NBTTagCompound = NBTTagCompound()) : IMessage, IMessageHandler<ClientComponentUpdatePacket, IMessage> {
+
+    override fun fromBytes(buf: ByteBuf?) {
+        tag = ByteBufUtils.readTag(buf)!!
+    }
+
+    override fun toBytes(buf: ByteBuf?) {
+        ByteBufUtils.writeTag(buf, tag)
+    }
+
+    override fun onMessage(packet: ClientComponentUpdatePacket, ctx: MessageContext): IMessage? {
+        val te = ctx.serverHandler.player.world.getTileEntity(BlockPos.fromLong(packet.tag.getLong("pos")))
+        if (te is MultiblockTileEntityBase) {
+            (te.multiblockController as BaseMultiBlock).getComponents().filter { it.first == packet.tag.getString("name") }.forEach { (_, component) ->
+                component.deserializeNBT(tag.getCompoundTag("component"))
+            }
+        } else if (te is TCAggregatable) {
+            te.getComponents().filter { it.first == packet.tag.getString("name") }.forEach { (_, component) ->
+                component.deserializeNBT(tag.getCompoundTag("component"))
+            }
+        }
+        return null
+    }
+}

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/proxy/CommonProxy.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/proxy/CommonProxy.kt
@@ -249,6 +249,7 @@ open class CommonProxy {
         PacketHandler.registerPacket(ItemScrollPacket::class.java, ItemScrollPacket::class.java, Side.SERVER)
         PacketHandler.registerPacket(ItemKeyBindPacket::class.java, ItemKeyBindPacket::class.java, Side.SERVER)
         PacketHandler.registerPacket(MachineInfoPacket::class.java, MachineInfoPacket::class.java, Side.CLIENT)
+        PacketHandler.registerPacket(ClientComponentUpdatePacket::class.java, ClientComponentUpdatePacket::class.java, Side.SERVER)
     }
 
     open fun init() {

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/tileentity/MachineTileEntity.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/tileentity/MachineTileEntity.kt
@@ -113,9 +113,12 @@ open class MachineTileEntity : AggregatableTileEntity(), TCMachineTileEntity, IL
                     components.add(DefaultProgressBar((outputNearestToTheMiddle - inputNearestToTheMiddle) / 2 - 11 + inputNearestToTheMiddle, 40, Orientation.RIGHT, foundProgressComponent as ProgressComponent, gui))
             }
         })
+        initGui(gui)
         gui.registerTab(MachineSettingsTab(gui, this, player))
         return gui
     }
+
+    open fun initGui(gui:TCGui) {}
 
     override fun update() {
         // update ILogic strategies, but only server side

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/tileentity/machines/TileEntityAlloySmeltery.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/tileentity/machines/TileEntityAlloySmeltery.kt
@@ -1,6 +1,9 @@
 package net.cydhra.technocracy.foundation.tileentity.machines
 
 import net.cydhra.technocracy.foundation.capabilities.inventory.DynamicInventoryHandler
+import net.cydhra.technocracy.foundation.client.gui.TCGui
+import net.cydhra.technocracy.foundation.client.gui.components.label.DefaultLabel
+import net.cydhra.technocracy.foundation.client.gui.tabs.TCTab
 import net.cydhra.technocracy.foundation.crafting.IMachineRecipe
 import net.cydhra.technocracy.foundation.crafting.RecipeManager
 import net.cydhra.technocracy.foundation.tileentity.MachineTileEntity
@@ -55,5 +58,13 @@ class TileEntityAlloySmeltery : MachineTileEntity(), TEInventoryProvider {
                 && (0 until this.inputInventoryComponent.inventory.slots).all { index ->
             index == slot || !this.inputInventoryComponent.inventory.getStackInSlot(index).isItemEqual(stack)
         }
+    }
+
+    override fun initGui(gui: TCGui) {
+        gui.registerTab(object: TCTab("Example", gui) {
+            override fun init() {
+                addComponent(DefaultLabel(10, 20, "Hello World"))
+            }
+        })
     }
 }

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/tileentity/multiblock/TileEntityMultiBlockPart.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/tileentity/multiblock/TileEntityMultiBlockPart.kt
@@ -175,8 +175,11 @@ abstract class TileEntityMultiBlockPart<T>(private val clazz: KClass<T>, private
                     components.add(DefaultProgressBar((outputNearestToTheMiddle - inputNearestToTheMiddle) / 2 - 11 + inputNearestToTheMiddle, 40, Orientation.RIGHT, foundProgressComponent as ProgressComponent, gui))
             }
         })
+        initGui(gui)
         gui.registerTab(MultiblockSettingsTab(gui, this, player))
         return gui
     }
+
+    open fun initGui(gui: TCGui) {}
 
 }

--- a/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/tileentity/multiblock/refinery/TileEntityRefineryController.kt
+++ b/technocracy.foundation/src/main/kotlin/net/cydhra/technocracy/foundation/tileentity/multiblock/refinery/TileEntityRefineryController.kt
@@ -1,6 +1,9 @@
 package net.cydhra.technocracy.foundation.tileentity.multiblock.refinery
 
 import net.cydhra.technocracy.foundation.capabilities.fluid.DynamicFluidHandler
+import net.cydhra.technocracy.foundation.client.gui.TCGui
+import net.cydhra.technocracy.foundation.client.gui.components.label.DefaultLabel
+import net.cydhra.technocracy.foundation.client.gui.tabs.TCTab
 import net.cydhra.technocracy.foundation.liquids.general.heavyOilFluid
 import net.cydhra.technocracy.foundation.liquids.general.lightOilFluid
 import net.cydhra.technocracy.foundation.liquids.general.mineralOilFluid
@@ -45,5 +48,13 @@ class TileEntityRefineryController : TileEntityMultiBlockPart<RefineryMultiBlock
     override fun readFromNBT(data: NBTTagCompound) {
         super.readFromNBT(data)
         this.deserializeNBT(data)
+    }
+
+    override fun initGui(gui: TCGui) {
+        gui.registerTab(object:TCTab("Example", gui) {
+            override fun init() {
+                addComponent(DefaultLabel(10, 20, "Hello World"))
+            }
+        })
     }
 }


### PR DESCRIPTION
component updates by the user/player are send to the server
custom tabs must not implement title rendering (was moved to the TCTab class)
added label component (might be usefull for custom tabs later)
machines & multiblocks can register own (custom) tabs
fixed items in TCSlotIO were rendered on wrong tabs